### PR TITLE
refactor: transform Swal api to dialog.showMessageBox api to show info message

### DIFF
--- a/src/main/onLoad.js
+++ b/src/main/onLoad.js
@@ -188,6 +188,13 @@ function onLoad() {
             win.loadURL(`data:text/html;charset=utf-8,<pre>${content}</pre>`);
         }
     );
+    // 显示提示信息
+    ipcMain.handle(
+        "LiteLoader.qqpromote.showMessageBox",
+        async (event, options) => {
+            return await dialog.showMessageBox(options);
+        }
+    );
 }
 
 module.exports = {

--- a/src/preload.js
+++ b/src/preload.js
@@ -54,5 +54,9 @@ contextBridge.exposeInMainWorld("qqpromote", {
     showQrContent: (content) => ipcRenderer.invoke( // TODO: 使用更加具体的 API 进行替换(目前API仅开发使用)
         "LiteLoader.qqpromote.showQrContent",
         content
-    )
+    ),
+    showMessageBox: (options) => ipcRenderer.invoke(
+        "LiteLoader.qqpromote.showMessageBox",
+        options
+    ),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -18,11 +18,6 @@ let login_time = 3;
 async function onLoad() {
     const setting_data = await qqpromote.getSettings()
     const plugin_path = LiteLoader.plugins.qqpromote.path.plugin;
-    const script = document.createElement("script");
-    script.id = "sweetalert2"
-    script.defer = true;
-    script.src = "https://cdn.jsdelivr.net/npm/sweetalert2@10";
-    document.head.appendChild(script);
     // CSS
     const css_file_path = `local:///${plugin_path}/src/config/message.css`;
     const link_element = document.createElement("link");
@@ -61,22 +56,25 @@ async function onLoad() {
         if (location.hash !== "#/main/message" && location.href.indexOf("#/chat/") == -1) return
         if (!(LiteLoader?.plugins?.LLAPI?.manifest?.version >= "1.3.1")) {
             setTimeout(() => {
-                Swal.fire({
-                    title: 'LLAPI版本过低，请在插件市场安装最新版',
-                    text: '该提示并非QQ官方提示，请不要发给官方群',
-                    icon: 'warning',
-                    showCancelButton: true,
-                    confirmButtonText: '前往插件市场',
-                    cancelButtonText: '确定',
-                }).then((result) => {
-                    if (result.isConfirmed) {
+                qqpromote.showMessageBox({
+                    message: "LLAPI版本过低, 请在插件市场安装最新版",
+                    detail: "该提示并非QQ官方提示, 请不要发给官方群",
+                    type: "warning",
+                    buttons: ["前往插件市场", "确定"],
+                  }).then((result) => {
+                    if (result.response === 0) {
                         try {
                             StoreAPI.openStore("LLAPI");
                         } catch (error) {
-                            Swal.fire('未安装插件市场', '该提示并非QQ官方提示，请不要发给官方群', 'warning');
+                            qqpromote.showMessageBox({
+                                message: "未安装插件市场",
+                                detail: "该提示并非QQ官方提示, 请不要发给官方群",
+                                type: "warning",
+                                buttons: ["确定"],
+                            })
                         }
                     }
-                });
+                  })
             }, 1000);
         }
         clearInterval(Interval);


### PR DESCRIPTION
transform all Swal api to dialog, and delete the dependence of Swal. 
>[!NOTE]
>It's  temporarily using dialog apis, you can change them to your better apis later! (but now I think these are better than Swal!)